### PR TITLE
Add mobile navigation arrows and disable touch swipe navigation

### DIFF
--- a/public/modules/navController.js
+++ b/public/modules/navController.js
@@ -15,6 +15,7 @@ export function initNavController(options = {}) {
   const totalPanels = panels.length;
   const initialIndex = clampIndex(options.initialIndex ?? 0, totalPanels);
   const autoRedirect = options.autoRedirect;
+  const isMobileViewport = window.matchMedia('(max-width: 768px)').matches;
 
   let currentIndex = initialIndex;
   let isAnimating = false;
@@ -144,8 +145,10 @@ export function initNavController(options = {}) {
   });
 
   main.addEventListener('wheel', throttledWheel, { passive: false });
-  main.addEventListener('touchstart', handleTouchStart, { passive: false });
-  main.addEventListener('touchmove', handleTouchMove, { passive: false });
+  if (!isMobileViewport) {
+    main.addEventListener('touchstart', handleTouchStart, { passive: false });
+    main.addEventListener('touchmove', handleTouchMove, { passive: false });
+  }
   document.addEventListener('keydown', handleKey);
   document.addEventListener('visibilitychange', handleVisibility);
   onLanguageChange(updateStatusText);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1359,9 +1359,23 @@ textarea:focus-visible {
     display: none;
   }
 
-  /* Hide nav arrows on mobile */
+  /* Reposition nav arrows for mobile experience */
   .nav-arrow {
-    display: none;
+    display: grid;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.75);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  }
+
+  .nav-arrow--up {
+    top: auto;
+    bottom: 5.25rem;
+  }
+
+  .nav-arrow--down {
+    bottom: 1.5rem;
   }
 
   /* Hide nav progress dots on mobile */


### PR DESCRIPTION
## Summary
- enable navigation arrows on mobile with centered positioning
- disable touch-swipe section changes on mobile viewports

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693624c6b9b0832bac34673df1241dd4)